### PR TITLE
BUXFIX: syntax error in parseAndGet.UpdateRecord() has been fixed.

### DIFF
--- a/Assets/Scripts/SQLiteORM/DatabaseManager.cs
+++ b/Assets/Scripts/SQLiteORM/DatabaseManager.cs
@@ -163,6 +163,13 @@ namespace Assets.Scripts
                 return true;
             return false;
         }
+        
+        public bool DeleteRecord<T>(string fieldNameSearch, object valueSearch)
+        {
+            if (ExecuteScript(new ParseAndGet().RemoveItems<T>(fieldNameSearch, valueSearch)))
+                return true;
+            return false;
+        }
 
         public bool DropTable<T>()
         {

--- a/Assets/Scripts/SQLiteORM/ParseAndGet.cs
+++ b/Assets/Scripts/SQLiteORM/ParseAndGet.cs
@@ -151,7 +151,7 @@ namespace Assets.Scripts
                 switch ((it.GetValue(newItem, null)).GetType().Name)
                 {
                     case "Boolean":
-                        body_text += it.Name + string.Format("{0}, ", (it.GetValue(newItem, null).ToString() == "False") ? 0 : 1);
+                        body_text += it.Name + " = "+ string.Format("{0}, ", (it.GetValue(newItem, null).ToString() == "False") ? 0 : 1);
                         break;
 
                     case "Int32":
@@ -181,7 +181,7 @@ namespace Assets.Scripts
 
                 }
             }
-            footer_text = " WHERE " + fieldNameSearch + " = " + valueSearch;
+            footer_text = " WHERE " + fieldNameSearch + " = '" + valueSearch + "'";
             return string.Format("{0}{1}{2}", header_text, body_text.Substring(0, body_text.Length - 2), footer_text); 
         }
         //

--- a/Assets/Scripts/SQLiteORM/ParseAndGet.cs
+++ b/Assets/Scripts/SQLiteORM/ParseAndGet.cs
@@ -133,6 +133,16 @@ namespace Assets.Scripts
             else
                 return "DELETE FROM " + typeof(T).Name + " WHERE Id  = " + value;
         }
+        
+        public string RemoveItems<T>(string fieldNameSearch, object valueSearch)
+        {
+            if (valueSearch.GetType().Name == "String" || valueSearch.GetType().Name == "DateTime")
+                return "DELETE FROM " + typeof(T).Name + " WHERE " + fieldNameSearch + "  = '" + valueSearch + "'";
+            else
+                return "DELETE FROM " + typeof(T).Name + " WHERE " + fieldNameSearch + "  = " + valueSearch;
+        }
+        
+        
         public string UpdateItemsByFieldName<T>(string fieldNameSearch, string valueSearch, string fieldNameToUpdate, string newValue)
         {
             return "UPDATE " + typeof(T).Name + " SET " + fieldNameToUpdate + " = " + newValue + " WHERE " + fieldNameSearch + " = " + valueSearch;


### PR DESCRIPTION
There was a forgotten "=" for boolean and also single quotations for creating query in ParseAndGet.cs 